### PR TITLE
Improve the formatting of ExceptionString

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -37,15 +37,13 @@ class ArrayBufferAllocator : public ArrayBuffer::Allocator {
 // Exception details will be appended to the first argument.
 std::string ExceptionString(Isolate* isolate, TryCatch* try_catch) {
   std::string out;
-  size_t scratchSize = 100;
+  size_t scratchSize = 20;
   char scratch[scratchSize]; // just some scratch space for sprintf
 
   HandleScope handle_scope(isolate);
   String::Utf8Value exception(try_catch->Exception());
   const char* exception_string = ToCString(exception);
   
-  printf("exception string: %s\n", exception_string);
-
   Handle<Message> message = try_catch->Message();
 
   if (message.IsEmpty()) {
@@ -54,13 +52,16 @@ std::string ExceptionString(Isolate* isolate, TryCatch* try_catch) {
     out.append(exception_string);
     out.append("\n");
   } else {
-    // Print (filename):(line number): (message).
+    // Print (filename):(line number)
     String::Utf8Value filename(message->GetScriptOrigin().ResourceName());
     const char* filename_string = ToCString(filename);
     int linenum = message->GetLineNumber();
 
-    snprintf(scratch, scratchSize, "%s:%i: %s\n", filename_string, linenum, exception_string);
+    snprintf(scratch, scratchSize, "%i", linenum);
+    out.append(filename_string);
+    out.append(":");
     out.append(scratch);
+    out.append("\n");
 
     // Print line of source code.
     String::Utf8Value sourceline(message->GetSourceLine());
@@ -83,6 +84,9 @@ std::string ExceptionString(Isolate* isolate, TryCatch* try_catch) {
     if (stack_trace.length() > 0) {
       const char* stack_trace_string = ToCString(stack_trace);
       out.append(stack_trace_string);
+      out.append("\n");
+    } else {
+      out.append(exception_string);
       out.append("\n");
     }
   }


### PR DESCRIPTION
The `ExceptionString` output currently gets garbled on long error messages due to the scratch space not being sufficiently large, e.g.

```
exception string: SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
~foo/bar/test.js:8: SyntaxError: Block-scoped declarations (let, const, function, class) not yet sufor (let i of x) {
     ^^^
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```

The current output is also unnecessarily repetitive, e.g. if the error returned from `worker.Load()` is dumped to stdout, you get to experience the fun of seeing the same error message thrice!

This patch generates slightly better formatted output, e.g.

```
~foo/bar/test.js:8
for (let i of x) {
     ^^^
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```

It does make the assumption that the `StackTrace()` includes the main `Exception()` when the message/stacktrace aren't empty though — which may or may not be a valid assumption. But, hopefully, you know more about the V8 API and can make a judgment call on that.

Thanks!
