### PR TITLE
fixed memory leak

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -57,6 +57,9 @@ func New(cb ReceiveMessageCallback) *Worker {
 func (w *Worker) Load(scriptName string, code string) error {
 	scriptName_s := C.CString(scriptName)
 	code_s := C.CString(code)
+	defer C.free(unsafe.Pointer(scriptName_s))
+	defer C.free(unsafe.Pointer(code_s))
+
 	r := C.worker_load(w.cWorker, scriptName_s, code_s)
 	if r != 0 {
 		errStr := C.GoString(C.worker_last_exception(w.cWorker))


### PR DESCRIPTION
I hit >600MB memory usage after 10K requests of rendering of react.js components.

quote @ry 

```
let me know if you can find a test case for the mem leak
```

Sorry I didn't have a testcase for it. I spotted the memory leak and it was a easy fix.

```
    defer C.free(unsafe.Pointer(scriptName_s))
    defer C.free(unsafe.Pointer(code_s))
```
