### PR TITLE
Use cstring (this was necessary to compile on my ubuntu box)

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string>
+#include <cstring>
 #include "v8.h"
 #include "libplatform/libplatform.h"
 #include "binding.h"

--- a/build.sh
+++ b/build.sh
@@ -23,10 +23,12 @@ libv8_snapshot=`find $outdir -name 'libv8_snapshot.a' | head -1`""
 
 # for Linux
 librt=''
+libdl=''
 start_group=''
 end_group=''
 if [ `go env | grep GOHOSTOS` == 'GOHOSTOS="linux"' ]; then
 	librt='-lrt'
+	libdl='-ldl'
 	start_group='-Wl,--start-group'
 	end_group='-Wl,--end-group'
 fi
@@ -43,4 +45,4 @@ Description: v8 javascript engine
 Version: $target
 Cflags: $libstdcpp -I`pwd`/v8/include -I`pwd`/v8/
 Libs: $libstdcpp $start_group $libv8_libbase $libv8_base $libv8_libplatform \
-$libv8_snapshot $end_group $librt" > v8.pc
+$libv8_snapshot $end_group $librt $libdl" > v8.pc


### PR DESCRIPTION
I don't know much about C++, but this change was necessary to install on my ubuntu box.

Before this change I saw the following error:

```
$ make install
go install
# github.com/ry/v8worker
./binding.cc: In member function ‘virtual void* ArrayBufferAllocator::Allocate(size_t)’:
./binding.cc:30:56: error: ‘memset’ was not declared in this scope
     return data == NULL ? data : memset(data, 0, length);
                                                        ^
make: *** [install] Error 2
```

I googled around and found http://stackoverflow.com/questions/26832672/error-memset-was-not-declared-in-this-scope, added cstring as recommended, and was able to build the project successfully. 
