### PR TITLE
Allow worker to be killed when golang proxy is reclaimed

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -367,4 +367,9 @@ worker* worker_new(worker_recv_cb cb, worker_recvSync_cb recvSync_cb, void* data
   return w;
 }
 
+void worker_kill(worker* w) {
+  w->isolate->Dispose();
+  delete(w);
+}
+
 }

--- a/binding.h
+++ b/binding.h
@@ -26,6 +26,8 @@ const char* worker_last_exception(worker* w);
 int worker_send(worker* w, const char* msg);
 const char* worker_sendSync(worker* w, const char* msg);
 
+void worker_kill(worker* w);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/worker.go
+++ b/worker.go
@@ -11,6 +11,7 @@ import "errors"
 
 import "unsafe"
 import "sync"
+import "runtime"
 
 // To receive messages from javascript...
 type ReceiveMessageCallback func(msg string)
@@ -67,6 +68,9 @@ func New(cb ReceiveMessageCallback, recvSync_cb ReceiveSyncMessageCallback) *Wor
 	receiveSync_callback := C.worker_recvSync_cb(C.go_recvSync_cb)
 
 	worker.cWorker = C.worker_new(callback, receiveSync_callback, unsafe.Pointer(worker))
+	runtime.SetFinalizer(worker, func(final_worker *Worker) {
+		C.worker_kill(final_worker.cWorker) //Delete this worker on finalize (GC)
+	})
 	return worker
 }
 


### PR DESCRIPTION
This change sets a finalizer on the golang "worker" object,
which allows it to send a worker_kill signal to the C++ side of things
which in turn allows the C++ code to Dispose() of the V8 Isolate,
as well as "delete" the C++ wrapping struct for the worker.

This effectively means that whenever a worker is removed by the go GC,
it gets clean up properly.

I wrote a UT to create 10000 workers in a loop, and without the finalizer,
noticed that memory usage went up to 3 GBs. However with the finalizer code,
the test ran much faster and general performance was up, along with
memory usage being capped at only 8 MBs.

The process for running the test:
/usr/bin/time -lp go test ./...

It should print useful output.
