### PR TITLE
Update for latest stable version of V8 (4.8)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-version?=4.3.59
+version?=4.8-lkgr
 target?=native # available: x64.debug, ia32.debug, ia32.release, x64.release
 
 test: v8worker.test

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ outdir="`pwd`/v8/out/$target"
 libv8_base="`find $outdir -name 'libv8_base.a' | head -1`"
 libv8_libbase="`find $outdir -name 'libv8_libbase.a' | head -1`"
 libv8_libplatform=`find $outdir -name 'libv8_libplatform.a' | head -1`""
-libv8_snapshot=`find $outdir -name 'libv8_snapshot.a' | head -1`""
+libv8_snapshot=`find $outdir -name 'libv8_nosnapshot.a' | head -1`""
 
 # for Linux
 libs=''

--- a/worker_test.go
+++ b/worker_test.go
@@ -34,6 +34,12 @@ func TestBasic(t *testing.T) {
 		t.Fatal("Expected error")
 	}
 	//println(err.Error())
+    
+    codeWithArrayBufferAllocator := ` var _utf8len = new Uint8Array(256); $print(_utf8len); `
+	err = worker.Load("buffer.js", codeWithArrayBufferAllocator)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	codeWithRecv := `
 		$recv(function(msg) {


### PR DESCRIPTION
Latest v8 uses own ArrayBufferAllocator per isolate, so i put it in worker_s structure. Also makefile uses 4.8-last_known_good_release version by default. I'm not sure about libv8_nosnapshot.a in build.sh, but it works and tests passes.
