### PR TITLE
Memory leak fix, LoadWithOptions method

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -147,6 +147,14 @@ int worker_load(worker* w, char* source_s, char* name_s, int line_offset_s, int 
   return 0;
 }
 
+void worker_low_memory_notification(worker* w) {
+  w->isolate->LowMemoryNotification();
+}
+
+bool worker_idle_notification_deadline(worker* w, double deadline_in_seconds) {
+  return w->isolate->IdleNotificationDeadline(deadline_in_seconds);
+}
+
 void Print(const FunctionCallbackInfo<Value>& args) {
   bool first = true;
   for (int i = 0; i < args.Length(); i++) {

--- a/binding.cc
+++ b/binding.cc
@@ -21,16 +21,14 @@ class ArrayBufferAllocator : public ArrayBuffer::Allocator {
 };
 
 struct worker_s {
-  int x;
-  int table_index;
-  worker_recv_cb cb;
-  worker_recv_sync_cb sync_cb;
   Isolate* isolate;
   ArrayBufferAllocator allocator;
   std::string last_exception;
   Persistent<Function> recv;
   Persistent<Context> context;
   Persistent<Function> recv_sync_handler;
+  void* cb;
+  void* sync_cb;
 };
 
 // Extracts a C string from a V8 Utf8Value.
@@ -100,14 +98,6 @@ std::string ExceptionString(Isolate* isolate, TryCatch* try_catch) {
 
 extern "C" {
 #include "_cgo_export.h"
-
-void go_recv_cb(const char* msg, int table_index) {
-  recvCb((char*)msg, table_index);
-}
-
-const char* go_recv_sync_cb(const char* msg, int table_index) {
-  return recvSyncCb((char*)msg, table_index);
-}
 
 const char* worker_version() {
   return V8::GetVersion();
@@ -233,7 +223,7 @@ void Send(const FunctionCallbackInfo<Value>& args) {
   }
 
   // XXX should we use Unlocker?
-  w->cb(msg.c_str(), w->table_index);
+  recvCb((char*)msg.c_str(), w->cb);
 }
 
 // Called from javascript using $request.
@@ -258,7 +248,7 @@ void SendSync(const FunctionCallbackInfo<Value>& args) {
     String::Utf8Value str(v);
     msg = ToCString(str);
   }
-  const char* returnMsg = w->sync_cb(msg.c_str(), w->table_index);
+  const char* returnMsg = recvSyncCb((char*)msg.c_str(), w->sync_cb);
   Local<String> returnV = String::NewFromUtf8(w->isolate, returnMsg);
   args.GetReturnValue().Set(returnV);
 }
@@ -326,8 +316,6 @@ const char* worker_send_sync(worker* w, const char* msg) {
   return out.c_str();
 }
 
-static ArrayBufferAllocator array_buffer_allocator;
-
 void v8_init() {
   V8::InitializeICU();
   Platform* platform = platform::CreateDefaultPlatform();
@@ -335,7 +323,7 @@ void v8_init() {
   V8::Initialize();
 }
 
-worker* worker_new(worker_recv_cb cb, worker_recv_sync_cb sync_cb, int table_index) {
+worker* worker_new(void* cb, void* sync_cb) {
   worker* w = new(worker);
 
   Isolate::CreateParams create_params;
@@ -348,7 +336,6 @@ worker* worker_new(worker_recv_cb cb, worker_recv_sync_cb sync_cb, int table_ind
   w->isolate = isolate;
   w->isolate->SetCaptureStackTraceForUncaughtExceptions(true);
   w->isolate->SetData(0, w);
-  w->table_index = table_index;
   w->cb = cb;
   w->sync_cb = sync_cb;
 

--- a/binding.cc
+++ b/binding.cc
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 #include <string>
 #include "v8.h"
 #include "libplatform/libplatform.h"
@@ -116,7 +117,7 @@ const char* worker_last_exception(worker* w) {
   return w->last_exception.c_str();
 }
 
-int worker_load(worker* w, char* name_s, char* source_s) {
+int worker_load(worker* w, char* source_s, char* name_s, int line_offset_s, int column_offset_s, bool is_shared_cross_origin_s, int script_id_s, bool is_embedder_debug_script_s, char* source_map_url_s, bool is_opaque_s) {
   Locker locker(w->isolate);
   Isolate::Scope isolate_scope(w->isolate);
   HandleScope handle_scope(w->isolate);
@@ -128,8 +129,15 @@ int worker_load(worker* w, char* name_s, char* source_s) {
 
   Local<String> name = String::NewFromUtf8(w->isolate, name_s);
   Local<String> source = String::NewFromUtf8(w->isolate, source_s);
+  Local<Integer> line_offset = Integer::New(w->isolate, line_offset_s);
+  Local<Integer> column_offset = Integer::New(w->isolate, column_offset_s);
+  Local<Boolean> is_shared_cross_origin = Boolean::New(w->isolate, is_shared_cross_origin_s);
+  Local<Integer> script_id = Integer::New(w->isolate, script_id_s);
+  Local<Boolean> is_embedder_debug_script = Boolean::New(w->isolate, is_embedder_debug_script_s);
+  Local<String> source_map_url = String::NewFromUtf8(w->isolate, source_map_url_s);
+  Local<Boolean> is_opaque = Boolean::New(w->isolate, is_opaque_s);
 
-  ScriptOrigin origin(name);
+  ScriptOrigin origin(name, line_offset, column_offset, is_shared_cross_origin, script_id, is_embedder_debug_script, source_map_url, is_opaque);
 
   Local<Script> script = Script::Compile(source, &origin);
 

--- a/binding.h
+++ b/binding.h
@@ -24,6 +24,8 @@ const char* worker_send_sync(worker* w, const char* msg);
 
 void worker_dispose(worker* w);
 void worker_terminate_execution(worker* w);
+void worker_low_memory_notification(worker* w);
+bool worker_idle_notification_deadline(worker* w, double deadline_in_seconds);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/binding.h
+++ b/binding.h
@@ -11,7 +11,7 @@ const char* worker_version();
 
 void v8_init();
 
-worker* worker_new(void* cb, void* sync_cb);
+worker* worker_new(int worker_id);
 
 // returns nonzero on error
 // get error from worker_last_exception

--- a/binding.h
+++ b/binding.h
@@ -4,19 +4,14 @@ extern "C" {
 
 #include <stdbool.h>
 
-void go_recv_cb(const char* msg, int table_index);
-const char* go_recv_sync_cb(const char* msg, int table_index);
-
 struct worker_s;
 typedef struct worker_s worker;
-typedef void (*worker_recv_cb)(const char* msg, int table_index);
-typedef const char* (*worker_recv_sync_cb)(const char* msg, int table_index);
 
 const char* worker_version();
 
 void v8_init();
 
-worker* worker_new(worker_recv_cb cb, worker_recv_sync_cb sync_cb, int table_index);
+worker* worker_new(void* cb, void* sync_cb);
 
 // returns nonzero on error
 // get error from worker_last_exception

--- a/binding.h
+++ b/binding.h
@@ -4,19 +4,14 @@ extern "C" {
 
 #include <stdbool.h>
 
-void go_recv_cb(const char* msg, int table_index);
-const char* go_recv_sync_cb(const char* msg, int table_index);
-
 struct worker_s;
 typedef struct worker_s worker;
-typedef void (*worker_recv_cb)(const char* msg, int table_index);
-typedef const char* (*worker_recv_sync_cb)(const char* msg, int table_index);
 
 const char* worker_version();
 
 void v8_init();
 
-worker* worker_new(worker_recv_cb cb, worker_recv_sync_cb sync_cb, int table_index);
+worker* worker_new(int worker_id);
 
 // returns nonzero on error
 // get error from worker_last_exception

--- a/binding.h
+++ b/binding.h
@@ -2,6 +2,7 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 
 void go_recv_cb(const char* msg, int table_index);
 const char* go_recv_sync_cb(const char* msg, int table_index);
@@ -19,7 +20,7 @@ worker* worker_new(worker_recv_cb cb, worker_recv_sync_cb sync_cb, int table_ind
 
 // returns nonzero on error
 // get error from worker_last_exception
-int worker_load(worker* w, char* name_s, char* source_s);
+int worker_load(worker* w, char* source_s, char* name_s, int line_offset_s, int column_offset_s, bool is_shared_cross_origin_s, int script_id_s, bool is_embedder_debug_script_s, char* source_map_url_s, bool is_opaque_s);
 
 const char* worker_last_exception(worker* w);
 

--- a/worker.go
+++ b/worker.go
@@ -65,16 +65,18 @@ func Version() string {
 func recvCb(msg_s *C.char, workerId int) {
 	msg := C.GoString(msg_s)
 	callbacksMapLocker.RLock()
-	callbacksMap[workerId].cb(msg)
+	fn := callbacksMap[workerId].cb
 	callbacksMapLocker.RUnlock()
+	fn(msg)
 }
 
 //export recvSyncCb
 func recvSyncCb(msg_s *C.char, workerId int) *C.char {
 	msg := C.GoString(msg_s)
 	callbacksMapLocker.RLock()
-	res := callbacksMap[workerId].syncCB(msg)
+	fn := callbacksMap[workerId].syncCB
 	callbacksMapLocker.RUnlock()
+	res := fn(msg)
 	return C.CString(res)
 }
 

--- a/worker.go
+++ b/worker.go
@@ -6,12 +6,13 @@ package v8worker
 #include <stdlib.h>
 #include "binding.h"
 */
-import "C"
-import "errors"
-
-import "unsafe"
-import "sync"
-import "runtime"
+import (
+	"C"
+	"errors"
+	"runtime"
+	"sync"
+	"unsafe"
+)
 
 type workerTableIndex int
 

--- a/worker.go
+++ b/worker.go
@@ -6,8 +6,8 @@ package v8worker
 #include <stdlib.h>
 #include "binding.h"
 */
+import "C"
 import (
-	"C"
 	"errors"
 	"runtime"
 	"sync"

--- a/worker.go
+++ b/worker.go
@@ -108,6 +108,12 @@ func New(cb ReceiveMessageCallback, syncCB ReceiveSyncMessageCallback) *Worker {
 	return worker
 }
 
+// Optional notification that the embedder is idle.
+// http://v8.paulfryzel.com/docs/master/classv8_1_1_isolate.html#aba794ed25d4fa8780b3a07c66a5e5d4a
+func (w *Worker) IdleNotificationDeadline(deadLineInSeconds float64) bool {
+	return bool(C.worker_idle_notification_deadline(w.cWorker, C.double(deadLineInSeconds)))
+}
+
 // Load loads and executes a javascript file with the filename specified by
 // scriptName and the contents of the file specified by the param code.
 func (w *Worker) Load(scriptName string, code string) error {
@@ -144,6 +150,13 @@ func (w *Worker) LoadWithOptions(origin *ScriptOrigin, code string) error {
 		return errors.New(errStr)
 	}
 	return nil
+}
+
+// LowMemoryNotification for optional notification that the system is running low on memory.
+// V8 uses these notifications to attempt to free memory.
+// http://v8.paulfryzel.com/docs/master/classv8_1_1_isolate.html#aaf446f4877e4707a93d2c406fffd9fd6
+func (w *Worker) LowMemoryNotification() {
+	C.worker_low_memory_notification(w.cWorker)
 }
 
 // Send sends a message to a worker. The $recv callback in js will be called.

--- a/worker_test.go
+++ b/worker_test.go
@@ -61,9 +61,9 @@ func TestBasic(t *testing.T) {
 	}
 }
 
-func TestUnit8Array(t *testing.T) {
+func TestUint8Array(t *testing.T) {
 	worker := New(func(msg string) {}, DiscardSendSync)
-	codeWithArrayBufferAllocator := ` var _utf8len = new Uint8Array(256); $print(_utf8len); `
+	codeWithArrayBufferAllocator := ` var uint8 = new Uint8Array(256); $print(uint8); `
 	err := worker.Load("buffer.js", codeWithArrayBufferAllocator)
 	if err != nil {
 		t.Fatal(err)

--- a/worker_test.go
+++ b/worker_test.go
@@ -197,7 +197,7 @@ func TestWorkerBreaking(t *testing.T) {
 	worker.Load("forever.js", ` while (true) { ; } `)
 }
 
-func TestWithOptions(t *testing.T) {
+func TestLoadWithOptions(t *testing.T) {
 	worker := New(func(msg string) {
 		println("recv cb", msg)
 	}, DiscardSendSync)

--- a/worker_test.go
+++ b/worker_test.go
@@ -2,6 +2,7 @@ package v8worker
 
 import (
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -194,4 +195,38 @@ func TestWorkerBreaking(t *testing.T) {
 	}(worker)
 
 	worker.Load("forever.js", ` while (true) { ; } `)
+}
+
+func TestWithOptions(t *testing.T) {
+	worker := New(func(msg string) {
+		println("recv cb", msg)
+	}, DiscardSendSync)
+	origin := &ScriptOrigin{
+		ScriptName: "options.js",
+	}
+	expected := `options.js:1:7`
+	err := worker.LoadWithOptions(origin, `throw new Error("Error")`)
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatal("Bad stack trace", err.Error())
+	}
+	origin = &ScriptOrigin{
+		ScriptName:   "options.js",
+		LineOffset:   3,
+		ColumnOffset: 2,
+	}
+	expected = `options.js:4:9`
+	err = worker.LoadWithOptions(origin, `throw new Error("Error")`)
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatal("Bad stack trace", err.Error())
+	}
+	expected = `VM0:1:7`
+	err = worker.LoadWithOptions(nil, `throw new Error("Error")`)
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatal("Bad stack trace", err.Error())
+	}
+	expected = `VM1:1:7`
+	err = worker.LoadWithOptions(nil, `throw new Error("Error")`)
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatal("Bad stack trace", err.Error())
+	}
 }

--- a/worker_test.go
+++ b/worker_test.go
@@ -2,6 +2,7 @@ package v8worker
 
 import (
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -203,14 +204,9 @@ func TestWithOptions(t *testing.T) {
 	origin := &ScriptOrigin{
 		ScriptName: "options.js",
 	}
-	expected := `options.js:1
-throw new Error("Error")
-^
-Error: Error
-    at options.js:1:7
-`
+	expected := `options.js:1:7`
 	err := worker.LoadWithOptions(origin, `throw new Error("Error")`)
-	if err.Error() != expected {
+	if !strings.Contains(err.Error(), expected) {
 		t.Fatal("Bad stack trace", err.Error())
 	}
 	origin = &ScriptOrigin{
@@ -218,34 +214,19 @@ Error: Error
 		LineOffset:   3,
 		ColumnOffset: 2,
 	}
-	expected = `options.js:4
-throw new Error("Error")
-  ^
-Error: Error
-    at options.js:4:9
-`
+	expected = `options.js:4:9`
 	err = worker.LoadWithOptions(origin, `throw new Error("Error")`)
-	if err.Error() != expected {
+	if !strings.Contains(err.Error(), expected) {
 		t.Fatal("Bad stack trace", err.Error())
 	}
-	expected = `VM0:1
-throw new Error("Error")
-^
-Error: Error
-    at VM0:1:7
-`
+	expected = `VM0:1:7`
 	err = worker.LoadWithOptions(nil, `throw new Error("Error")`)
-	if err.Error() != expected {
+	if !strings.Contains(err.Error(), expected) {
 		t.Fatal("Bad stack trace", err.Error())
 	}
-	expected = `VM1:1
-throw new Error("Error")
-^
-Error: Error
-    at VM1:1:7
-`
+	expected = `VM1:1:7`
 	err = worker.LoadWithOptions(nil, `throw new Error("Error")`)
-	if err.Error() != expected {
+	if !strings.Contains(err.Error(), expected) {
 		t.Fatal("Bad stack trace", err.Error())
 	}
 }


### PR DESCRIPTION
Hi. [Fix for Go 1.6](https://github.com/ry/v8worker/commit/0298d9d8960846f1899c7332d7dcbf8b465f99f7) led to a new issue - workersTable map began to save links to workers, and GC not destruct them without manual table cleanup. We did create other map for callback, without links to worker.
There is a new method LoadWithOptions. We left 'Load' signature untouched for backward compatibility.
We also did small improvements in Go code according to guidelines
